### PR TITLE
COPC write optimizations: octree structure reuse + parallel chunk compression

### DIFF
--- a/laspy/copcwriter.py
+++ b/laspy/copcwriter.py
@@ -3,7 +3,7 @@ import logging
 import math
 from collections import deque
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from typing import BinaryIO, List, Optional, Union
 
@@ -64,7 +64,9 @@ def _morton_codes(
 @dataclass
 class OctreeChunk:
     key: VoxelKey
-    point_indices: np.ndarray
+    # Either an index array (freshly built octree) or a slice of the
+    # point array (structure reused from a source COPC file).
+    point_indices: Union[np.ndarray, slice]
 
 
 @dataclass
@@ -74,6 +76,9 @@ class OctreeResult:
     center: np.ndarray
     halfsize: float
     spacing: float
+    # Hierarchy entries with point_count == 0, preserved when reusing
+    # the structure of a source COPC file.
+    zero_keys: List[VoxelKey] = field(default_factory=list)
 
 
 def _build_octree(
@@ -273,6 +278,131 @@ def _build_octree(
     )
 
 
+def _chunks_still_contained(
+    points: PackedPointRecord,
+    header: LasHeader,
+    copc_info: CopcInfoVlr,
+    entries: List[Entry],
+    starts: np.ndarray,
+) -> bool:
+    """Check that every chunk's points still lie inside its node's cube.
+
+    Attribute-only edits always pass. Coordinate edits that moved points
+    out of their octree nodes make this return False, in which case the
+    octree must be rebuilt.
+    """
+    side = 2.0 * float(copc_info.halfsize)
+    root_min = np.asarray(copc_info.center, dtype=np.float64) - copc_info.halfsize
+
+    levels = np.array([e.key.level for e in entries], dtype=np.float64)
+    keys = np.array([[e.key.x, e.key.y, e.key.z] for e in entries], dtype=np.float64)
+    node_side = side / np.exp2(levels)
+
+    seg = starts[:-1].astype(np.intp)
+    for axis, dim in enumerate(("X", "Y", "Z")):
+        arr = np.ascontiguousarray(points[dim])
+        chunk_min = np.minimum.reduceat(arr, seg).astype(np.float64)
+        chunk_max = np.maximum.reduceat(arr, seg).astype(np.float64)
+
+        scale = header.scales[axis]
+        offset = header.offsets[axis]
+        node_min = (root_min[axis] + keys[:, axis] * node_side - offset) / scale
+        node_max = node_min + node_side / scale
+        # Tolerance of one integer unit, plus slack for float rounding.
+        eps = 1.0 + node_side * 1e-9 / scale
+        if np.any(chunk_min < node_min - eps) or np.any(chunk_max > node_max + eps):
+            return False
+    return True
+
+
+def _structure_from_header(
+    header: LasHeader, points: PackedPointRecord
+) -> Optional[OctreeResult]:
+    """Recover the octree layout of the source COPC file from its header
+    (CopcInfoVlr + CopcHierarchyVlr), so that an edited file can be written
+    without rebuilding the octree.
+
+    When a COPC file is read sequentially (laspy.read), points are
+    decompressed chunk after chunk in file order and each LAZ chunk is one
+    octree node. Hierarchy entries sorted by chunk offset therefore give
+    each node its slice of the point array.
+
+    Returns None when the structure cannot be reused: the header does not
+    come from a COPC file, the hierarchy is inconsistent with the points,
+    or points were moved outside their nodes.
+    """
+    n_points = len(points)
+    if n_points == 0:
+        return None
+
+    copc_info = next((v for v in header.vlrs if isinstance(v, CopcInfoVlr)), None)
+    if copc_info is None or copc_info.halfsize <= 0.0 or copc_info.spacing <= 0.0:
+        return None
+
+    hierarchy = None
+    for vlr_list in (header.evlrs, header.vlrs):
+        if vlr_list is None:
+            continue
+        hierarchy = next(
+            (v for v in vlr_list if isinstance(v, CopcHierarchyVlr)), None
+        )
+        if hierarchy is not None:
+            break
+    if hierarchy is None:
+        return None
+
+    # The hierarchy EVLR payload is a concatenation of pages, and pages are
+    # flat arrays of entries, so the whole payload can be parsed as entries.
+    # Entries with point_count == -1 only reference a child page (whose
+    # entries are in the same payload) and are skipped.
+    data = hierarchy.data
+    entry_size = VoxelKey.unpacker.size + Entry.unpacker.size
+    if not data or len(data) % entry_size != 0:
+        return None
+
+    point_entries = []
+    zero_keys = []
+    seen_keys = set()
+    for i in range(0, len(data), entry_size):
+        entry = Entry.from_bytes(data[i : i + entry_size])
+        if entry.point_count == -1:
+            continue
+        if entry.key in seen_keys:
+            return None
+        seen_keys.add(entry.key)
+        if entry.point_count == 0:
+            zero_keys.append(entry.key)
+        else:
+            point_entries.append(entry)
+
+    if sum(e.point_count for e in point_entries) != n_points:
+        return None
+
+    point_entries.sort(key=lambda e: e.offset)
+    counts = np.array([e.point_count for e in point_entries], dtype=np.int64)
+    starts = np.concatenate(([0], np.cumsum(counts)))
+
+    if not _chunks_still_contained(points, header, copc_info, point_entries, starts):
+        return None
+
+    chunks = [
+        OctreeChunk(
+            key=entry.key,
+            point_indices=slice(int(starts[i]), int(starts[i + 1])),
+        )
+        for i, entry in enumerate(point_entries)
+    ]
+
+    return OctreeResult(
+        chunks=chunks,
+        intermediate_keys=[],
+        center=np.array(copc_info.center, dtype=np.float64),
+        halfsize=float(copc_info.halfsize),
+        spacing=float(copc_info.spacing),
+        zero_keys=zero_keys,
+    )
+
+
 class CopcWriter:
     """Writes point cloud data as a COPC (Cloud Optimized Point Cloud) file.
 
@@ -287,6 +417,7 @@ class CopcWriter:
         points: PackedPointRecord,
         target_points_per_node: int = 100_000,
         max_depth: Optional[int] = None,
+        reuse_structure: bool = True,
     ) -> None:
         """Write points as a COPC file.
 
@@ -302,6 +433,12 @@ class CopcWriter:
             Target number of points per octree leaf node.
         max_depth : int, optional
             Maximum octree depth. Auto-computed if None.
+        reuse_structure : bool
+            When the header comes from a COPC file (e.g. laspy.read of a
+            .copc.laz) and the points still fit the source octree, reuse
+            that octree instead of rebuilding it. Attribute edits keep the
+            structure valid; coordinate edits that break it automatically
+            fall back to a full rebuild.
         """
         if lazrs is None:
             raise LaspyException("COPC writing requires the 'lazrs' package")
@@ -318,9 +455,13 @@ class CopcWriter:
 
         if isinstance(destination, str):
             with open(destination, "wb+") as f:
-                CopcWriter._write_copc(f, header, points, target_points_per_node, max_depth)
+                CopcWriter._write_copc(
+                    f, header, points, target_points_per_node, max_depth, reuse_structure
+                )
         else:
-            CopcWriter._write_copc(destination, header, points, target_points_per_node, max_depth)
+            CopcWriter._write_copc(
+                destination, header, points, target_points_per_node, max_depth, reuse_structure
+            )
 
     @staticmethod
     def _write_copc(
@@ -329,6 +470,7 @@ class CopcWriter:
         points: PackedPointRecord,
         target_points_per_node: int,
         max_depth: Optional[int],
+        reuse_structure: bool = True,
     ) -> None:
         header = deepcopy(header)
         header.are_points_compressed = True
@@ -367,8 +509,18 @@ class CopcWriter:
             header.maxs = [0.0, 0.0, 0.0]
             header.mins = [0.0, 0.0, 0.0]
 
-        # Build octree
-        octree = _build_octree(points, header, target_points_per_node, max_depth)
+        # Reuse the octree structure of the source COPC file when possible,
+        # otherwise build a new octree.
+        octree = None
+        if reuse_structure:
+            octree = _structure_from_header(header, points)
+        if octree is not None:
+            logger.info(
+                "Reusing COPC octree structure from source (%d chunks)",
+                len(octree.chunks),
+            )
+        else:
+            octree = _build_octree(points, header, target_points_per_node, max_depth)
 
         # Create CopcInfoVlr with placeholder hierarchy offset
         copc_info = CopcInfoVlr()
@@ -427,7 +579,7 @@ class CopcWriter:
         last_idx = len(octree.chunks) - 1
         for i, chunk in enumerate(octree.chunks):
             idx = chunk.point_indices
-            n_pts = len(idx)
+            n_pts = (idx.stop - idx.start) if isinstance(idx, slice) else len(idx)
 
             # Extract point bytes: copies only n_pts × point_size uint8 bytes.
             chunk_bytes = point_records_2d[idx].ravel()
@@ -466,6 +618,12 @@ class CopcWriter:
             chunk_table_offset = int.from_bytes(dest.read(8), "little", signed=True)
             dest.seek(saved_pos)
             entries[-1].byte_size = chunk_table_offset - entries[-1].offset
+
+        # Preserve empty-node entries when reusing a source hierarchy
+        for key in octree.zero_keys:
+            entry = Entry()
+            entry.key = key
+            entries.append(entry)
 
         # Build hierarchy EVLR data (all entries concatenated)
         entry_bytes = b"".join(e.to_bytes() for e in entries)

--- a/laspy/copcwriter.py
+++ b/laspy/copcwriter.py
@@ -23,6 +23,15 @@ except ModuleNotFoundError:
 
 logger = logging.getLogger(__name__)
 
+# Parallel per-chunk compression needs lazrs APIs added in recent versions.
+_HAS_PARALLEL_CHUNKS = lazrs is not None and hasattr(
+    getattr(lazrs, "ParLasZipCompressor", None), "compress_chunks"
+) and hasattr(lazrs, "read_chunk_table")
+
+# Chunks compressed per compress_chunks call. Bounds transient memory to
+# ~one batch of compressed chunks while keeping all cores busy.
+_PARALLEL_CHUNK_BATCH = 32
+
 _MORTON_BITS = 21                        # bits per dimension in Morton code
 _MORTON_MAX  = (1 << _MORTON_BITS) - 1  # 2097151
 
@@ -464,6 +473,120 @@ class CopcWriter:
             )
 
     @staticmethod
+    def _compress_chunks_parallel(
+        dest: BinaryIO,
+        laz_vlr,
+        chunks: List[OctreeChunk],
+        point_records_2d: np.ndarray,
+        offset_to_point_data: int,
+    ) -> List[Entry]:
+        """Compress octree chunks on all cores via ParLasZipCompressor.
+
+        Each buffer passed to compress_chunks becomes exactly one LAZ chunk;
+        chunks are fed in batches so at most one batch of compressed chunks
+        is held in memory. Per-chunk byte sizes are recovered from the chunk
+        table that done() writes.
+        """
+        compressor = lazrs.ParLasZipCompressor(dest, laz_vlr)
+        # After compressor init, it writes 8-byte chunk table offset placeholder
+        # First chunk starts at offset_to_point_data + 8
+        for start in range(0, len(chunks), _PARALLEL_CHUNK_BATCH):
+            batch = chunks[start : start + _PARALLEL_CHUNK_BATCH]
+            # Slices (reuse path) stay zero-copy views; index arrays
+            # (rebuild path) copy only this batch's rows.
+            compressor.compress_chunks(
+                [point_records_2d[c.point_indices].ravel() for c in batch]
+            )
+            for chunk in batch:
+                chunk.point_indices = None
+        compressor.done()
+        end_of_data = dest.tell()
+
+        dest.seek(offset_to_point_data)
+        chunk_table = lazrs.read_chunk_table(dest, laz_vlr)
+        dest.seek(end_of_data)
+        if chunk_table is None or len(chunk_table) != len(chunks):
+            raise LaspyException(
+                "Chunk table inconsistent after parallel COPC compression "
+                f"({None if chunk_table is None else len(chunk_table)} entries "
+                f"for {len(chunks)} chunks)"
+            )
+
+        entries = []
+        chunk_start = offset_to_point_data + 8
+        for chunk, (point_count, byte_size) in zip(chunks, chunk_table):
+            entry = Entry()
+            entry.key = chunk.key
+            entry.offset = chunk_start
+            entry.byte_size = int(byte_size)
+            entry.point_count = int(point_count)
+            entries.append(entry)
+            chunk_start += int(byte_size)
+        return entries
+
+    @staticmethod
+    def _compress_chunks_sequential(
+        dest: BinaryIO,
+        laz_vlr,
+        chunks: List[OctreeChunk],
+        point_records_2d: np.ndarray,
+        offset_to_point_data: int,
+    ) -> List[Entry]:
+        """Single-threaded fallback for lazrs versions without compress_chunks
+        (also handles the 0-point file, whose single empty chunk the parallel
+        API is not exercised with)."""
+        compressor = lazrs.LasZipCompressor(dest, laz_vlr)
+        # After compressor init, it writes 8-byte chunk table offset placeholder
+        # First chunk starts at offset_to_point_data + 8
+
+        chunk_start = offset_to_point_data + 8
+        entries = []
+
+        last_idx = len(chunks) - 1
+        for i, chunk in enumerate(chunks):
+            idx = chunk.point_indices
+            n_pts = (idx.stop - idx.start) if isinstance(idx, slice) else len(idx)
+
+            # Extract point bytes: copies only n_pts × point_size uint8 bytes.
+            chunk_bytes = point_records_2d[idx].ravel()
+
+            compressor.compress_many(chunk_bytes)
+            # Skip finish_current_chunk on the final chunk: done() finalizes it.
+            # Calling both produces a phantom empty chunk in the LAZ chunk table
+            # (n_chunks = real + 1), which breaks LASzip C++ readers (CloudCompare).
+            if i != last_idx:
+                compressor.finish_current_chunk()
+
+            # Free chunk indices — no longer needed after compression.
+            chunk.point_indices = None
+
+            entry = Entry()
+            entry.key = chunk.key
+            entry.offset = chunk_start
+            entry.point_count = n_pts
+            # byte_size for non-last chunks: end position - start. Last chunk
+            # is backfilled after done() from the chunk table offset.
+            if i != last_idx:
+                chunk_end = dest.tell()
+                entry.byte_size = chunk_end - chunk_start
+                chunk_start = chunk_end
+            else:
+                entry.byte_size = 0
+            entries.append(entry)
+
+        compressor.done()
+
+        # Last chunk ends where the chunk table starts. lazrs wrote the chunk
+        # table offset into the 8-byte placeholder at offset_to_point_data.
+        if entries:
+            saved_pos = dest.tell()
+            dest.seek(offset_to_point_data)
+            chunk_table_offset = int.from_bytes(dest.read(8), "little", signed=True)
+            dest.seek(saved_pos)
+            entries[-1].byte_size = chunk_table_offset - entries[-1].offset
+        return entries
+
+    @staticmethod
     def _write_copc(
         dest: BinaryIO,
         header: LasHeader,
@@ -563,61 +686,20 @@ class CopcWriter:
         offset_to_point_data = header.offset_to_point_data
 
         # Write compressed chunks
-        compressor = lazrs.LasZipCompressor(dest, laz_vlr)
-        # After compressor init, it writes 8-byte chunk table offset placeholder
-        # First chunk starts at offset_to_point_data + 8
-
-        chunk_start = offset_to_point_data + 8
-        entries = []
-
         point_size = header.point_format.size
         # View point data as 2D array (n_points, point_size) — zero-copy reshape.
         # Fancy indexing then copies only selected rows, avoiding the large
         # byte_offsets matrix (which was n_pts × point_size × 8 bytes).
         point_records_2d = np.frombuffer(points.array, dtype=np.uint8).reshape(-1, point_size)
 
-        last_idx = len(octree.chunks) - 1
-        for i, chunk in enumerate(octree.chunks):
-            idx = chunk.point_indices
-            n_pts = (idx.stop - idx.start) if isinstance(idx, slice) else len(idx)
-
-            # Extract point bytes: copies only n_pts × point_size uint8 bytes.
-            chunk_bytes = point_records_2d[idx].ravel()
-
-            compressor.compress_many(chunk_bytes)
-            # Skip finish_current_chunk on the final chunk: done() finalizes it.
-            # Calling both produces a phantom empty chunk in the LAZ chunk table
-            # (n_chunks = real + 1), which breaks LASzip C++ readers (CloudCompare).
-            if i != last_idx:
-                compressor.finish_current_chunk()
-
-            # Free chunk indices — no longer needed after compression.
-            chunk.point_indices = None
-
-            entry = Entry()
-            entry.key = chunk.key
-            entry.offset = chunk_start
-            entry.point_count = n_pts
-            # byte_size for non-last chunks: end position - start. Last chunk
-            # is backfilled after done() from the chunk table offset.
-            if i != last_idx:
-                chunk_end = dest.tell()
-                entry.byte_size = chunk_end - chunk_start
-                chunk_start = chunk_end
-            else:
-                entry.byte_size = 0
-            entries.append(entry)
-
-        compressor.done()
-
-        # Last chunk ends where the chunk table starts. lazrs wrote the chunk
-        # table offset into the 8-byte placeholder at offset_to_point_data.
-        if entries:
-            saved_pos = dest.tell()
-            dest.seek(offset_to_point_data)
-            chunk_table_offset = int.from_bytes(dest.read(8), "little", signed=True)
-            dest.seek(saved_pos)
-            entries[-1].byte_size = chunk_table_offset - entries[-1].offset
+        if _HAS_PARALLEL_CHUNKS and len(points) > 0:
+            entries = CopcWriter._compress_chunks_parallel(
+                dest, laz_vlr, octree.chunks, point_records_2d, offset_to_point_data
+            )
+        else:
+            entries = CopcWriter._compress_chunks_sequential(
+                dest, laz_vlr, octree.chunks, point_records_2d, offset_to_point_data
+            )
 
         # Preserve empty-node entries when reusing a source hierarchy
         for key in octree.zero_keys:

--- a/tests/test_copc.py
+++ b/tests/test_copc.py
@@ -430,3 +430,30 @@ def test_copc_edit_rewrite_rebuilds_on_count_preserving_reorder(monkeypatch):
 
     with laspy.CopcReader(io.BytesIO(output.getvalue())) as reader:
         assert len(reader.query()) == len(las)
+
+
+@pytest.mark.skipif("not laspy.LazBackend.Lazrs.is_available()")
+def test_copc_parallel_and_sequential_writes_are_equivalent(monkeypatch):
+    import laspy.copcwriter as copcwriter
+
+    assert copcwriter._HAS_PARALLEL_CHUNKS, "lazrs is expected to support compress_chunks"
+
+    las = laspy.read(SIMPLE_COPC_FILE)
+    las.classification[:] = 3
+
+    parallel_out = io.BytesIO()
+    laspy.CopcWriter.write(parallel_out, las.header, las.points)
+
+    monkeypatch.setattr(copcwriter, "_HAS_PARALLEL_CHUNKS", False)
+    las = laspy.read(SIMPLE_COPC_FILE)
+    las.classification[:] = 3
+    sequential_out = io.BytesIO()
+    laspy.CopcWriter.write(sequential_out, las.header, las.points)
+
+    # Same compressor, same chunk boundaries -> byte-identical files
+    assert parallel_out.getvalue() == sequential_out.getvalue()
+
+    with laspy.CopcReader(io.BytesIO(parallel_out.getvalue())) as reader:
+        points = reader.query()
+        assert len(points) == len(las)
+        assert np.all(np.asarray(points.classification) == 3)

--- a/tests/test_copc.py
+++ b/tests/test_copc.py
@@ -301,3 +301,132 @@ def test_copc_selective_decompression(backend):
         != fully_decompressed_points.point_source_id
     )
     assert np.any(partially_decompressed_points.Z != fully_decompressed_points.Z)
+
+
+@pytest.mark.skipif("not laspy.LazBackend.Lazrs.is_available()")
+@pytest.mark.parametrize(
+    "copc_file",
+    [SIMPLE_COPC_FILE, SIMPLE_COPC_FILE.with_name("simple_with_page.copc.laz")],
+)
+def test_copc_edit_rewrite_reuses_octree(copc_file, monkeypatch):
+    # Editing attributes of a COPC file and re-writing it as COPC
+    # must reuse the source octree structure instead of rebuilding it.
+    import laspy.copcwriter as copcwriter
+
+    def fail_build(*args, **kwargs):
+        raise AssertionError("octree should not be rebuilt for attribute edits")
+
+    monkeypatch.setattr(copcwriter, "_build_octree", fail_build)
+
+    las = laspy.read(copc_file)
+    original_x = np.array(las.X)
+    las.classification[:] = 7
+
+    output = io.BytesIO()
+    laspy.CopcWriter.write(output, las.header, las.points)
+    data = output.getvalue()
+
+    # Data round-trips: same points in the same order, only classification changed
+    back = laspy.read(io.BytesIO(data))
+    assert np.array_equal(np.array(back.X), original_x)
+    assert np.all(np.array(back.classification) == 7)
+
+    # The rewritten file is a valid COPC with the same hierarchy
+    with laspy.CopcReader.open(copc_file) as source_reader:
+        source_entries = {
+            (k.level, k.x, k.y, k.z): e.point_count
+            for k, e in source_reader.root_page.entries.items()
+            if e.point_count != -1
+        }
+    with laspy.CopcReader(io.BytesIO(data)) as reader:
+        assert len(reader.query()) == len(las)
+        rewritten_entries = {
+            (k.level, k.x, k.y, k.z): e.point_count
+            for k, e in reader.root_page.entries.items()
+        }
+    # rewritten hierarchy is a single page containing at least all
+    # point-bearing entries of the source root page
+    for key, count in source_entries.items():
+        assert rewritten_entries[key] == count
+
+
+@pytest.mark.skipif("not laspy.LazBackend.Lazrs.is_available()")
+def test_copc_edit_rewrite_rebuilds_when_points_moved(monkeypatch):
+    # Coordinate edits that move points outside their octree nodes
+    # must fall back to a full octree rebuild.
+    import laspy.copcwriter as copcwriter
+
+    build_calls = []
+    original_build = copcwriter._build_octree
+
+    def counting_build(*args, **kwargs):
+        build_calls.append(1)
+        return original_build(*args, **kwargs)
+
+    monkeypatch.setattr(copcwriter, "_build_octree", counting_build)
+
+    las = laspy.read(SIMPLE_COPC_FILE)
+    span = int(
+        (las.header.maxs[0] - las.header.mins[0]) / las.header.scales[0]
+    )
+    las.X = np.asarray(las.X) + 4 * span
+
+    output = io.BytesIO()
+    laspy.CopcWriter.write(output, las.header, las.points)
+    assert build_calls, "moving points must trigger an octree rebuild"
+
+    with laspy.CopcReader(io.BytesIO(output.getvalue())) as reader:
+        assert len(reader.query()) == len(las)
+
+
+@pytest.mark.skipif("not laspy.LazBackend.Lazrs.is_available()")
+def test_copc_edit_rewrite_reuse_with_added_extra_dim(monkeypatch):
+    # Adding an extra dimension keeps point count and order, so the
+    # source octree must still be reused and the new dim round-trips.
+    import laspy.copcwriter as copcwriter
+
+    def fail_build(*args, **kwargs):
+        raise AssertionError("octree should not be rebuilt when adding a dim")
+
+    monkeypatch.setattr(copcwriter, "_build_octree", fail_build)
+
+    las = laspy.read(SIMPLE_COPC_FILE)
+    las.add_extra_dim(laspy.ExtraBytesParams(name="instance_id", type="i4"))
+    ids = np.arange(len(las), dtype=np.int32)
+    las.instance_id = ids
+
+    output = io.BytesIO()
+    laspy.CopcWriter.write(output, las.header, las.points)
+
+    back = laspy.read(io.BytesIO(output.getvalue()))
+    assert "instance_id" in back.point_format.extra_dimension_names
+    assert np.array_equal(np.asarray(back.instance_id), ids)
+
+
+@pytest.mark.skipif("not laspy.LazBackend.Lazrs.is_available()")
+def test_copc_edit_rewrite_rebuilds_on_count_preserving_reorder(monkeypatch):
+    # Reordering points keeps the point count, so only the per-chunk
+    # containment check can detect that the source octree is no longer
+    # valid. It must trigger a rebuild (on a multi-chunk file).
+    import laspy.copcwriter as copcwriter
+
+    build_calls = []
+    original_build = copcwriter._build_octree
+
+    def counting_build(*args, **kwargs):
+        build_calls.append(1)
+        return original_build(*args, **kwargs)
+
+    monkeypatch.setattr(copcwriter, "_build_octree", counting_build)
+
+    las = laspy.read(SIMPLE_COPC_FILE)
+    order = np.argsort(np.asarray(las.gps_time), kind="stable")
+    assert not np.array_equal(order, np.arange(len(las)))
+    reordered = las[order]
+
+    output = io.BytesIO()
+    laspy.CopcWriter.write(output, reordered.header, reordered.points)
+    assert build_calls, "count-preserving reorder must trigger a rebuild"
+
+    with laspy.CopcReader(io.BytesIO(output.getvalue())) as reader:
+        assert len(reader.query()) == len(las)


### PR DESCRIPTION
Makes the `read .copc.laz -> edit attributes -> write .copc.laz` flow roughly as cheap as the same flow on a regular `.laz`. No API changes: `las.write("out.copc.laz")` picks everything up automatically.

## Commit 1: Reuse source COPC octree structure when rewriting edited files

When a LasData read from a COPC file is written back as COPC, the octree layout is recovered from the source `CopcInfoVlr` + hierarchy EVLR instead of being rebuilt (no Morton sort / BFS / LOD resampling). Points decompress in chunk order, so hierarchy entries sorted by chunk offset map each node to a slice of the point array.

Reuse engages only when provably safe, three gates in order:
- header carries a valid `CopcInfoVlr` + hierarchy (multi-page hierarchies supported)
- hierarchy point counts sum to the actual point count
- every chunk's points still lie inside its node's cube (vectorized min/max per chunk, ~0.2s on 35M points)

Any gate failing falls back to the full rebuild: attribute edits reuse the octree, while point drops, count-preserving reorders and coordinate moves rebuild it. Verified against all point cloud mutation patterns used in flai-point-worker (20/20 correct path + valid output).

## Commit 2: Parallelize COPC chunk compression via lazrs compress_chunks

Octree chunks are independent LAZ chunks, so they are compressed on all cores with `lazrs.ParLasZipCompressor.compress_chunks` (rayon inside Rust), fed in batches of 32 to bound in-flight compressed data. Per-chunk byte sizes come from `lazrs.read_chunk_table`. The previous single-threaded loop remains as fallback (lazrs < 0.8, 0-point files); both paths produce byte-identical output (asserted by test).

## Benchmarks (35.6M point tile, GKOT_545_145.copc.laz, M1 Pro 10 cores)

| Phase | before | after |
|---|---|---|
| write (edit flow) | 31.4s | 2.6s |
| ... structure reuse alone | 31.4s | 11.2s |
| write (forced full rebuild) | 31.4s | 20.7s |
| peak RSS (whole flow) | 1.84 GB | 1.81 GB |

Write time is at parity with the regular parallel .laz write (2.3s) and scales with `RAYON_NUM_THREADS` (1/2/4/10 threads: 11.0/6.3/3.5/2.3s) with flat memory overhead and ~1% penalty at 1 thread versus the old sequential writer.

Output verified: hierarchy identical to source (keys, counts, geometry), all dimensions bit-identical except the edited one, same point order, fully queryable via CopcReader (spatial and LOD queries match source). Full test suite: 748 passed.
